### PR TITLE
Fix inconsistent format setting given to pip list

### DIFF
--- a/conda_env/pip_util.py
+++ b/conda_env/pip_util.py
@@ -61,11 +61,12 @@ def installed(prefix, output=True):
     pip_major_version = int(pip_version.split('.', 1)[0])
 
     env = os.environ.copy()
-    env[str('PIP_FORMAT')] = str('legacy')
     args.append('list')
 
     if pip_major_version >= 9:
         args += ['--format', 'json']
+    else:
+        env[str('PIP_FORMAT')] = str('legacy')
 
     try:
         pip_stdout = subprocess.check_output(args, universal_newlines=True, env=env)


### PR DESCRIPTION
This was causing conda env export to omit pip installed packages because later versions of pip (18.0) would fail when given conflicting formats.